### PR TITLE
Allow mid frame extraction WIP

### DIFF
--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -910,7 +910,7 @@ class StreamDecryptor(_EncryptionStream):  # pylint: disable=too-many-instance-a
                 
         if footer_frame:
             _LOGGER.debug("Reading footer")
-            self.footer = deserialize_footer(stream=self.source_stream, verifier=self.verifier)
+            self.footer = deserialize_footer(stream=self.source_stream, verifier=None)
 
         return plaintext
 


### PR DESCRIPTION
Minor untested modifications to allow frames to be extracted part way through.

I'm not keen on the api I've used here, a better idea might be to create a method called set_expected_frame_range(frame_from, frame_to) and a separate method to disable the footer_validation(false)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
